### PR TITLE
Fix checkbox resizing in PromptMaster

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -40,13 +40,7 @@
   }
   
   .pm-checkbox-label input[type="checkbox"] {
-    position: absolute;
-    opacity: 0;
-    width: 1rem;
-    height: 1rem;
-    margin: 0;
-    z-index: 2;
-    cursor: pointer;
+    @apply absolute opacity-0 w-4 h-4 m-0 z-20 cursor-pointer appearance-none box-border;
   }
   
   .pm-custom-checkbox {

--- a/style.css
+++ b/style.css
@@ -696,12 +696,16 @@ body {
 
 .pm-checkbox-label input[type="checkbox"] {
   position: absolute;
-  opacity: 0;
-  width: 1rem;
+  z-index: 20;
+  margin: 0px;
+  box-sizing: border-box;
   height: 1rem;
-  margin: 0;
-  z-index: 2;
+  width: 1rem;
   cursor: pointer;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  opacity: 0;
 }
 
 .pm-custom-checkbox {


### PR DESCRIPTION
## Summary
- avoid default checkbox sizing that alters layout when toggled
- rebuild Tailwind CSS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844fdc24964832e957d97e2c986fb24